### PR TITLE
fix(portforward): properly use errors.As

### DIFF
--- a/internal/proxier/portforward.go
+++ b/internal/proxier/portforward.go
@@ -423,7 +423,7 @@ func (w *worker) stopPortForward(ctx context.Context, conn *PortForwardConnectio
 			args := []string{"lo0", "-alias", ipStr}
 			if err := exec.Command("ifconfig", args...).Run(); err != nil {
 				message := ""
-				var exitError exec.ExitError
+				var exitError *exec.ExitError
 				if ok := errors.As(err, &exitError); ok {
 					message = string(exitError.Stderr)
 				}


### PR DESCRIPTION
`exec.ExitError` only implements the `error` interface if it is a
pointer (`Error()` is a pointer reciever). So, in order to use
`errors.As` we need to also set `exitError` to be `*exec.ExitError`.

Fixes #252
